### PR TITLE
[ci skip] remove atom-lint reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,11 +737,7 @@ Installation instructions can be found [here](https://github.com/mrdougal/textma
 
 ### Atom
 
-The [atom-lint](https://github.com/yujinakayama/atom-lint) package
-runs RuboCop and highlights the offenses in Atom.
-
-You can also use the [linter-rubocop](https://github.com/AtomLinter/linter-rubocop)
-plugin for Atom's [linter](https://github.com/AtomLinter/Linter).
+The linter-rubocop](https://github.com/AtomLinter/linter-rubocop) plugin for Atom's [linter](https://github.com/AtomLinter/Linter) runs RuboCop and highlights the offenses in Atom.
 
 ### LightTable
 


### PR DESCRIPTION
I think it's a bit useless recommending this no longer active plugin. See https://github.com/atom/atom/issues/6867
